### PR TITLE
Use a better upped bound (b value) to start the algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.jl.*.cov
 *.jl.cov
 *.jl.mem
+*.png
 /Manifest.toml
 /docs/Manifest.toml
 /docs/build/

--- a/src/PlaygroundWithGit.jl
+++ b/src/PlaygroundWithGit.jl
@@ -43,7 +43,7 @@ function loan_interest_calculator(; verbose = false, atol = 1e-6, rtol = 1e-6)
   f(x) = target_function(x)
 
   lower = 0.0
-  upper = 1.0
+  upper = monthly_payment / loan_amount
   f_lower, f_upper = f(lower), f(upper)
   solution = (lower + upper) / 2
   f_solution = f(solution)


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

Change the b value to be calculated as monthly_payment / borrowed_amount instead of a default

<!-- include screenshots if that helps the review -->

## List of related issues or pull requests

Closes #18

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing