### PR TITLE
Allow loan_interest_calculator to accept parameters

### DIFF
--- a/src/PlaygroundWithGit.jl
+++ b/src/PlaygroundWithGit.jl
@@ -3,11 +3,7 @@ module PlaygroundWithGit
 using Plots
 export loan_interest_calculator
 
-function loan_interest_calculator()
-  borrowed_amount = 500_000.0
-  number_of_payments = 360
-  monthly_payment = 2700.0
-
+function loan_interest_calculator(borrowed_amount, number_of_payments, monthly_payment)
   function target_function(interest_rate)
     if interest_rate == 0
       return monthly_payment - borrowed_amount / number_of_payments

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,10 @@ using PlaygroundWithGit
 using Test
 
 @testset "PlaygroundWithGit.jl" begin
-  x, fx = loan_interest_calculator()
+  borrowed_amount = 500_000.0
+  number_of_payments = 360
+  monthly_payment = 2700.0
+  x, fx = loan_interest_calculator(borrowed_amount, number_of_payments, monthly_payment)
   @test x ≈ 0.0042 atol = 1e-5
   @test fx ≈ 0 atol = 1e-5
 end


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request

We now have there new parameters: borrowed_amount, number_of_payments, monthly_payment instead of hard coded values

<!-- include screenshots if that helps the review -->

## List of related issues or pull requests

Closes #5

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [x] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing