### PR TITLE
Added input parameters to loan_interest_calculator

### DIFF
--- a/src/PlaygroundWithGit.jl
+++ b/src/PlaygroundWithGit.jl
@@ -3,7 +3,14 @@ module PlaygroundWithGit
 using Plots, Printf
 export loan_interest_calculator
 
-function loan_interest_calculator(loan_amount, number_of_payments, monthly_payment; verbose = false, atol = 1e-6, rtol = 1e-6)
+function loan_interest_calculator(
+  loan_amount,
+  number_of_payments,
+  monthly_payment;
+  verbose = false,
+  atol = 1e-6,
+  rtol = 1e-6,
+)
   function target_function(interest_rate)
     if interest_rate == 0
       return monthly_payment - loan_amount / number_of_payments

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,14 @@ using PlaygroundWithGit
 using Test
 
 @testset "PlaygroundWithGit.jl" begin
-  x, fx = loan_interest_calculator(500_000.0, 360, 2700.0; verbose = true, rtol = 1e-12, atol = 1e-12)
+  x, fx = loan_interest_calculator(
+    500_000.0,
+    360,
+    2700.0;
+    verbose = true,
+    rtol = 1e-12,
+    atol = 1e-12,
+  )
   @test x ≈ 0.0042 atol = 1e-5
   @test fx ≈ 0 atol = 1e-5
 end


### PR DESCRIPTION
# Pull request details

## Describe the changes made in this pull request
Added three input parameters to loan_interest_calculator so that they are no longer hard-coded.
The default values that were hard-coded are now used in the tests.

## List of related issues or pull requests

Closes #5

## Collaboration confirmation

As a contributor I confirm

- [x] I read and followed the instructions in README.dev.md
- [ ] The documentation is up to date with the changes introduced in this Pull Request (or NA)
- [x] Tests are passing
- [x] Lint is passing